### PR TITLE
refactor(friend) : repository access by query for visibility

### DIFF
--- a/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/friend/controller/FriendController.java
+++ b/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/friend/controller/FriendController.java
@@ -18,13 +18,13 @@ public class FriendController {
     private final FriendService friendService;
 
     @PostMapping
-    public ResponseEntity<String> addFriend(
+    public ResponseEntity<Void> addFriend(
             @RequestParam Long userId,
             @SessionAttribute(name = Const.LOGIN_USER) LoginUserResponseDto loginUser
     ) {
         Long requestUserId = loginUser.getId();
         friendService.sendFriendRequest(requestUserId, userId);
-        return new ResponseEntity<>("Success", HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping
@@ -37,12 +37,12 @@ public class FriendController {
     }
 
     @DeleteMapping
-    public ResponseEntity<String> deleteFriend(
+    public ResponseEntity<Void> deleteFriend(
             @RequestParam Long userId,
             @SessionAttribute(name = Const.LOGIN_USER) LoginUserResponseDto loginUser
     ) {
         Long requestUserId = loginUser.getId();
         friendService.delete(requestUserId, userId);
-        return new ResponseEntity<>("Success", HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/friend/dto/UserResponseDto.java
+++ b/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/friend/dto/UserResponseDto.java
@@ -1,12 +1,19 @@
 package xyz.tomorrowlearncamp.newsfeed.domain.friend.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class UserResponseDto {
-    private Long id;
-    private String username;
-    private String email;
+    private final Long id;
+    private final String username;
+    private final String email;
+
+    @Builder
+    public UserResponseDto(Long id, String username, String email) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+    }
 }

--- a/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/friend/repository/FriendRepository.java
@@ -1,6 +1,8 @@
 package xyz.tomorrowlearncamp.newsfeed.domain.friend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import xyz.tomorrowlearncamp.newsfeed.domain.users.entity.Users;
 import xyz.tomorrowlearncamp.newsfeed.domain.friend.entity.Friend;
@@ -12,7 +14,28 @@ import java.util.Optional;
 
 @Repository
 public interface FriendRepository extends JpaRepository<Friend,Long> {
-    Optional<Friend> findByRequestUserIdAndReceivedUserIdAndStatus(Long requestUserId, Long receivedUserId, FriendRequestStatus status);
-    List<Friend> findByReceivedUserIdAndStatus(Long receivedUserId, FriendRequestStatus status);
-    List<Friend> findByRequestUserIdAndStatus(Long requestUserId, FriendRequestStatus status);
+    @Query("SELECT f FROM Friend f WHERE f.receivedUserId = :userId AND f.status = :status")
+    List<Friend> findReceivedRequests(@Param("userId") Long userId, @Param("status") FriendRequestStatus status);
+
+    @Query("SELECT f FROM Friend f WHERE (f.requestUserId = :userId OR f.receivedUserId = :userId) AND f.status = :status")
+    List<Friend> findAcceptedFriends(@Param("userId") Long userId, @Param("status") FriendRequestStatus status);
+
+    //User1 에서 User2 으로 단방향 검색
+    @Query("SELECT f FROM Friend f WHERE (f.requestUserId = :user1 AND f.receivedUserId = :user2) " +
+            "AND f.status = :status")
+    Optional<Friend> findFriendshipRequest(
+            @Param("user1") Long user1,
+            @Param("user2") Long user2,
+            @Param("status") FriendRequestStatus status
+    );
+
+    //User1 에서 User2 로 혹은 User2 에서 User1 으로 양방향 검색
+    @Query("SELECT f FROM Friend f WHERE (f.requestUserId = :user1 AND f.receivedUserId = :user2) " +
+            "OR (f.requestUserId = :user2 AND f.receivedUserId = :user1) " +
+            "AND f.status = :status")
+    Optional<Friend> findFriendship(
+            @Param("user1") Long user1,
+            @Param("user2") Long user2,
+            @Param("status") FriendRequestStatus status
+    );
 }

--- a/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/friend/service/FriendService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/friend/service/FriendService.java
@@ -4,14 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.tomorrowlearncamp.newsfeed.domain.friend.dto.UserResponseDto;
-import xyz.tomorrowlearncamp.newsfeed.domain.users.entity.Users;
-import xyz.tomorrowlearncamp.newsfeed.domain.users.repository.UsersRepository;
+import xyz.tomorrowlearncamp.newsfeed.domain.users.dto.ResponseDto.ReadUsersResponseDto;
 import xyz.tomorrowlearncamp.newsfeed.domain.friend.entity.Friend;
 import xyz.tomorrowlearncamp.newsfeed.domain.friend.enums.FriendRequestStatus;
 import xyz.tomorrowlearncamp.newsfeed.domain.friend.repository.FriendRepository;
+import xyz.tomorrowlearncamp.newsfeed.domain.users.service.UsersService;
 import xyz.tomorrowlearncamp.newsfeed.global.exception.NotFoundUserException;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,22 +18,19 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class FriendService {
     private final FriendRepository friendRepository;
-    private final UsersRepository usersRepository;
+    private final UsersService usersService;
 
     @Transactional
     public void sendFriendRequest(Long requestUserId, Long receivedUserId) {
+
         if (requestUserId.equals(receivedUserId)) {
             throw new NotFoundUserException();
         }
+        usersService.validateUserExists(requestUserId);
+        usersService.validateUserExists(receivedUserId);
 
-        Users requestUser = usersRepository.findById(requestUserId)
-                .orElseThrow(NotFoundUserException::new);
-
-        Users receivedUser = usersRepository.findById(receivedUserId)
-                .orElseThrow(NotFoundUserException::new);
-
-        Optional<Friend> existingRequest = friendRepository.findByRequestUserIdAndReceivedUserIdAndStatus(
-                receivedUser.getId(), requestUser.getId(), FriendRequestStatus.WAITING
+        Optional<Friend> existingRequest = friendRepository.findFriendshipRequest(
+                receivedUserId, requestUserId, FriendRequestStatus.WAITING
         );
 
         Friend friendRequest;
@@ -43,48 +39,41 @@ public class FriendService {
             friendRequest = existingRequest.get();
             friendRequest.setStatus(FriendRequestStatus.ACCEPTED);
         } else {
-            friendRequest = new Friend(requestUser.getId(), receivedUser.getId(), FriendRequestStatus.WAITING);
+            friendRequest = new Friend(requestUserId, receivedUserId, FriendRequestStatus.WAITING);
         }
         friendRepository.save(friendRequest);
     }
 
     @Transactional(readOnly = true)
     public List<UserResponseDto> getFriendRequest(Long userId, String status) {
-        Users user = usersRepository.findById(userId)
-                .orElseThrow(NotFoundUserException::new);
+        usersService.validateUserExists(userId);
 
-        List<Long> ResponseList = new ArrayList<>();
-
-        if (status.equals("WAITING")) {
-            ResponseList = friendRepository.findByReceivedUserIdAndStatus(user.getId(), FriendRequestStatus.WAITING)
+        List<Long> responseList = switch (FriendRequestStatus.valueOf(status)) {
+            case WAITING -> friendRepository.findReceivedRequests(userId, FriendRequestStatus.WAITING)
                     .stream()
                     .map(Friend::getRequestUserId)
                     .toList();
-        } else if (status.equals("ACCEPTED")) {
-            List<Long> receivedUsers = friendRepository.findByRequestUserIdAndStatus(user.getId(), FriendRequestStatus.ACCEPTED)
+            case ACCEPTED -> friendRepository.findAcceptedFriends(userId, FriendRequestStatus.ACCEPTED)
                     .stream()
-                    .map(Friend::getReceivedUserId)
+                    .map(friend -> friend.getRequestUserId().equals(userId) ? friend.getReceivedUserId() : friend.getRequestUserId())
                     .toList();
-            List<Long> requestUsers = friendRepository.findByReceivedUserIdAndStatus(user.getId(), FriendRequestStatus.ACCEPTED)
-                    .stream()
-                    .map(Friend::getRequestUserId)
-                    .toList();
-            ResponseList.addAll(receivedUsers);
-            ResponseList.addAll(requestUsers);
-        } else {
-            throw new NotFoundUserException();
-        }
+            default -> throw new NotFoundUserException();
+        };
 
-        List<Users> usersList = usersRepository.findAllById(ResponseList);
-        return usersList.stream()
-                .map(users -> new UserResponseDto(users.getId(), users.getUsername(), users.getEmail()))
+        return responseList.stream()
+                .map(id -> {
+                    ReadUsersResponseDto user = usersService.getUserById(id);
+                    return UserResponseDto.builder()
+                            .id(user.getId())
+                            .username(user.getUsername())
+                            .email(user.getEmail())
+                            .build();
+                })
                 .toList();
     }
 
     public void delete(Long requestUserId, Long userId) {
-        Friend friend = friendRepository.findByRequestUserIdAndReceivedUserIdAndStatus(requestUserId, userId, FriendRequestStatus.ACCEPTED)
-                .orElseGet(() -> friendRepository.findByRequestUserIdAndReceivedUserIdAndStatus(userId, requestUserId, FriendRequestStatus.ACCEPTED)
-                .orElseThrow(NotFoundUserException::new));
+        Friend friend = friendRepository.findFriendship(requestUserId, userId, FriendRequestStatus.ACCEPTED).orElseThrow(NotFoundUserException::new);
 
         friendRepository.delete(friend);
     }

--- a/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/users/service/UsersService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/newsfeed/domain/users/service/UsersService.java
@@ -116,4 +116,10 @@ public class UsersService {
 
         users.delete();
     }
+
+    public void validateUserExists(Long userId) {
+        if (!usersRepository.existsById(userId)) {
+            throw new NotFoundUserException();
+        }
+    }
 }


### PR DESCRIPTION
1. Controller에서 Add 와 Delete 반환타입을 String 에서 Void로 변경
2. Dto에서 빌더 적용
3. Repository에서 JPA 제공문법 사용시 메서드명이 너무 길어져 직관적인 메서드 명으로 변경하고 Query를 변경하여 효율적으로 변경
4. Service에서도 Repository에 변경점에 맞춰 한번에 가져올 수 있도록 변경